### PR TITLE
[ Fix ] : loadWithHolder 함수 적용, 무한 신고 버그 해결, 피드백 수정

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ComplaintRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ComplaintRepository.kt
@@ -1,5 +1,6 @@
 package com.wannabeinseoul.seoulpublicservice.databases.firestore
 
+import android.util.Log
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import com.wannabeinseoul.seoulpublicservice.databases.entity.ComplaintEntity
@@ -14,7 +15,8 @@ class ComplaintRepositoryImpl : ComplaintRepository {
     private val fireStore = Firebase.firestore
 
     override suspend fun addComplaint(content: ComplaintEntity): String {
-        if (!checkComplaintId(content.complaintId.toString())) {
+        if (content.complaintId?.let { checkComplaintId(it) } == false) {
+            fireStore.collection("complaint").document(content.complaintId.toString()).set(hashMapOf("complaintId" to content.complaintId.toString()))
             fireStore.collection("complaint").document(content.complaintId.toString())
                 .collection("detailInfo").document(content.complaintTime.toString()).set(content)
 
@@ -24,7 +26,8 @@ class ComplaintRepositoryImpl : ComplaintRepository {
         }
 
         return if (fireStore.collection("complaint").document(content.complaintId.toString())
-                .collection("detailInfo").whereEqualTo("id", content.id).get().await()
+                .collection("detailInfo").whereEqualTo("complaintId", content.complaintId)
+                .whereEqualTo("id", content.id).get().await()
                 .isEmpty.not()
         ) "이미 신고한 사용자입니다." else ""
     }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/category/CategoryAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/category/CategoryAdapter.kt
@@ -10,6 +10,7 @@ import androidx.recyclerview.widget.RecyclerView
 import coil.load
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databinding.ItemCategoryBinding
+import com.wannabeinseoul.seoulpublicservice.util.loadWithHolder
 
 
 class CategoryAdapter(private val onItemClick: (svcid: String) -> Unit) :
@@ -20,7 +21,7 @@ class CategoryAdapter(private val onItemClick: (svcid: String) -> Unit) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: CategoryData) {
             binding.apply {
-                binding.ivCtImage.load(item.imageUrl)
+                binding.ivCtImage.loadWithHolder(item.imageUrl)
                 binding.tvCtServiceName.text = Html.fromHtml(item.serviceName, Html.FROM_HTML_MODE_LEGACY)
                 binding.tvCategoryItemPlace.text = item.placeName
                 binding.tvCtReservationEnd.text = item.isReservationAvailable

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/review/ReviewFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/review/ReviewFragment.kt
@@ -75,22 +75,6 @@ class ReviewFragment: BottomSheetDialogFragment() {
 
         rvReviewList.adapter = adapter
 
-        ivReviewSendBtn.setOnClickListener {
-            viewModel.uploadReview(svcId, etReviewInputField.text.toString())
-            setInitialState()
-            rvReviewList.layoutManager?.scrollToPosition(0)
-        }
-
-        etReviewInputField.setOnEditorActionListener { _, action, _ ->
-            if (action == EditorInfo.IME_ACTION_SEARCH) {
-                viewModel.uploadReview(svcId, etReviewInputField.text.toString())
-                setInitialState()
-                rvReviewList.layoutManager?.scrollToPosition(0)
-            }
-
-            false
-        }
-
         dialog?.setOnKeyListener { _, keyCode, event ->
             if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
                 dismiss()
@@ -110,6 +94,7 @@ class ReviewFragment: BottomSheetDialogFragment() {
 
         uiState.observe(viewLifecycleOwner) {
             adapter.submitList(it.toList())
+            binding.rvReviewList.smoothScrollToPosition(0)
             binding.tvReviewCount.text = it.size.toString()
             if (it.isNotEmpty()) {
                 binding.tvReviewCount.isVisible = true
@@ -127,14 +112,18 @@ class ReviewFragment: BottomSheetDialogFragment() {
                 binding.etReviewInputField.hint = "후기를 입력해주세요."
                 binding.ivReviewSendBtn.setImageResource(R.drawable.ic_send)
                 binding.ivReviewSendBtn.setOnClickListener {
-                    viewModel.uploadReview(svcId, binding.etReviewInputField.text.toString())
-                    setInitialState()
+                    if (binding.etReviewInputField.text.isNotEmpty()) {
+                        viewModel.uploadReview(svcId, binding.etReviewInputField.text.toString())
+                        setInitialState()
+                    }
                 }
 
                 binding.etReviewInputField.setOnEditorActionListener { _, action, _ ->
                     if (action == EditorInfo.IME_ACTION_SEARCH) {
-                        viewModel.uploadReview(svcId, binding.etReviewInputField.text.toString())
-                        setInitialState()
+                        if (binding.etReviewInputField.text.isNotEmpty()) {
+                            viewModel.uploadReview(svcId, binding.etReviewInputField.text.toString())
+                            setInitialState()
+                        }
                     }
 
                     false
@@ -143,14 +132,18 @@ class ReviewFragment: BottomSheetDialogFragment() {
                 binding.etReviewInputField.hint = "작성한 후기 수정만 가능합니다."
                 binding.ivReviewSendBtn.setImageResource(R.drawable.ic_revise)
                 binding.ivReviewSendBtn.setOnClickListener {
-                    viewModel.reviseReview(svcId, binding.etReviewInputField.text.toString())
-                    setInitialState()
+                    if (binding.etReviewInputField.text.isNotEmpty()) {
+                        viewModel.reviseReview(svcId, binding.etReviewInputField.text.toString())
+                        setInitialState()
+                    }
                 }
 
                 binding.etReviewInputField.setOnEditorActionListener { _, action, _ ->
                     if (action == EditorInfo.IME_ACTION_SEARCH) {
-                        viewModel.reviseReview(svcId, binding.etReviewInputField.text.toString())
-                        setInitialState()
+                        if (binding.etReviewInputField.text.isNotEmpty()) {
+                            viewModel.reviseReview(svcId, binding.etReviewInputField.text.toString())
+                            setInitialState()
+                        }
                     }
 
                     false

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/review/ReviewFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/review/ReviewFragment.kt
@@ -93,8 +93,9 @@ class ReviewFragment: BottomSheetDialogFragment() {
         checkWritableUser(svcId)
 
         uiState.observe(viewLifecycleOwner) {
-            adapter.submitList(it.toList())
-            binding.rvReviewList.smoothScrollToPosition(0)
+            adapter.submitList(it.toList()) {
+                binding.rvReviewList.smoothScrollToPosition(0)
+            }
             binding.tvReviewCount.text = it.size.toString()
             if (it.isNotEmpty()) {
                 binding.tvReviewCount.isVisible = true

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/adapter/HomeSearchAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/adapter/HomeSearchAdapter.kt
@@ -12,6 +12,7 @@ import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databases.ReservationEntity
 import com.wannabeinseoul.seoulpublicservice.databinding.ItemCategoryBinding
 import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryItemClick
+import com.wannabeinseoul.seoulpublicservice.util.loadWithHolder
 
 class HomeSearchAdapter(val items: List<ReservationEntity>) : RecyclerView.Adapter<HomeSearchAdapter.ViewHolder>() {
 
@@ -32,7 +33,7 @@ class HomeSearchAdapter(val items: List<ReservationEntity>) : RecyclerView.Adapt
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
         // ivImage에 coil 라이브러리를 사용하여 이미지 로드
-        holder.ivImage.load(item.IMGURL)
+        holder.ivImage.loadWithHolder(item.IMGURL)
         holder.tvServiceName.text = Html.fromHtml(item.SVCNM, Html.FROM_HTML_MODE_LEGACY)
         holder.tvPlaceName.text = item.PLACENM
         holder.tvIsFree.text = item.PAYATNM.take(2)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -250,8 +250,8 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                     if (it.value.size > 1) marker.captionText = it.value.size.toString()
                     marker.setCaptionAligns(Align.Top)
                     marker.captionTextSize = 16f
-                    marker.captionMinZoom = 13.0
-                    marker.captionMaxZoom = 14.8
+                    marker.captionMinZoom = 12.5
+                    marker.captionMaxZoom = 18.0
                     marker.onClickListener = Overlay.OnClickListener { _ ->
                         changeDetailVisible(true)
                         activeMarkers.forEach { marker ->


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [ ] 기능구현
- [x] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성

-기능
버그 해결

-설명
loadWithHolder가 적용되어있지 않던 이미지뷰에 적용

무한신고가 파이어스토어의 exists() 함수를 잘못 알고 있던 걸로 인해서 발생했다.
document에 대해서 exists() 함수를 쓸 때 collection만 연결하고 필드값이 없다면 무조건 false가 나온다는 걸 인지하지 않고 있었다. 그래서 필드값을 임의로 추가해 한번이라도 신고당한 사용자는 true가 나올 수 있도록 수정했다.

1. 마커 숫자 줌인 해도 보여주도록
마커의 captionMinZoom과 captionMaxZoom을 조절하며 수정

2. 후기칸을 빈칸으로 두고 후기를 올리는 케이스 없애기
현재 후기칸에 글자가 있는지 확인하고 후기에 대한 처리를 하도록 진행
→ 약간 시간이 걸렸는데 그 이유는 initView에서 선언한 클릭리스너가 돌지 않았기 때문
→ 디버깅을 해보니 라이브데이터 옵저빙하는 블록 내에서 따로 클릭 리스너를 추가해줬기 때문에 거기에 있는 클릭 리스너가 도는 상황이었다.
→ 거기에서 글자 유무를 확인하니까 잘 동작했다.
+추가) 스크롤 최상단으로 올리기
또 스크롤이 작동하지 않았다.
그래서 이번에는 짜놓은 코드를 바탕으로 챗gpt한테 물어보러 갔다.
거기서 알게 된 건(챗gpt가 알려준 건 아니고) 현재 리사이클러뷰에 아이템이 추가되기 전에 먼저 스크롤 함수가 작동을 해서 그런 것 같다는 직감이었다.
그래서 스크롤 함수를 이번에는 adapter.submitList를 호출하고 나서 호출하는 걸로 변경했더니 해결됐다.
→ 물론 자연스럽게 되지는 않고 트릭으로 데이터 넣을 때는 멈췄다가 서버에서 진짜 데이터가 들어오면 그 때서야 스크롤 함수가 작동하는 모양새다…ㅎ

## Merge 후 브랜치 보존 여부
합친 브랜치는 삭제하는 것을 기본값으로 합니다. 브랜치를 유지할 필요가 있는 경우에 체크해주시기 바랍니다.

- [ ] 반영된 브랜치 보존