### PR TITLE
[ Refactor ] : 메인 액티비티 구조 변경

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
@@ -617,6 +617,5 @@ class HomeFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         homeViewModel.loadRecentData()
-        setupRecentData()
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
@@ -28,7 +28,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
@@ -82,9 +82,9 @@ class HomeFragment : Fragment() {
         setupUIComponents()
     }
 
-    override fun onStop() {
-        homeViewModel.clearSearchResult()
-        super.onStop()
+    override fun onPause() {
+
+        super.onPause()
     }
 
     override fun onDestroyView() {
@@ -159,11 +159,6 @@ class HomeFragment : Fragment() {
 
                         // 검색을 수행할 때 cl_home_region_list를 숨김
                         clHomeRegionList.isVisible = false
-
-                        // tv_service_list, tab_layout, view_pager를 숨김
-                        tvServiceList.visibility = View.GONE
-                        tabLayout.visibility = View.GONE
-                        viewPager.visibility = View.GONE
 
                         // 검색 결과를 표시하는 RecyclerView를 보이게 함
                         rvSearchResults.visibility = View.VISIBLE
@@ -617,5 +612,7 @@ class HomeFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         homeViewModel.loadRecentData()
+        binding.etSearch.setText("")
+        binding.rvSearchResults.isVisible = false
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainActivity.kt
@@ -1,18 +1,14 @@
 package com.wannabeinseoul.seoulpublicservice.ui.main
 
 import android.Manifest
-import android.content.pm.PackageManager
 import android.os.Bundle
-import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
-import androidx.navigation.findNavController
-import androidx.navigation.ui.setupWithNavController
-import com.google.android.material.bottomnavigation.BottomNavigationView
+import androidx.viewpager2.widget.ViewPager2
 import com.naver.maps.map.util.FusedLocationSource
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.databinding.ActivityMainBinding
+import com.wannabeinseoul.seoulpublicservice.util.DLog
 
 private const val JJTAG = "jj-메인액티비티"
 
@@ -20,6 +16,10 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private val app by lazy { application as SeoulPublicServiceApplication }
+
+    private val viewPagerAdapter by lazy {
+        ViewPagerAdapter(this@MainActivity)
+    }
 
     private val permissions = arrayOf(
         Manifest.permission.ACCESS_FINE_LOCATION,
@@ -33,67 +33,41 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         app.fusedLocationSource = FusedLocationSource(this, 5000)
-
-//        if (!hasPermission()) {
         requestPermissions(permissions, 5000)  // 권한이 있든 없든 그냥 불러
-//        }
 
-//        // 앱의 lastLocation 갱신해두기
-//        /*
-//        앱 첫 실행 시 requestPermissions이 비동기인지 권한 받기 전에 아래가 실행되면서 권한 체크에서 터짐.
-//        권한 받고 나면 실행시키고 싶은데 콜백도 없는 것 같고.. 모르겠다...
-//         */
-//        CoroutineScope(Dispatchers.IO).launch {
-//            try {
-//                withTimeout(5_000L) {
-//                    // 권한 체크
-//                    if (ActivityCompat.checkSelfPermission(
-//                            this@MainActivity,
-//                            Manifest.permission.ACCESS_FINE_LOCATION
-//                        ) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(
-//                            this@MainActivity,
-//                            Manifest.permission.ACCESS_COARSE_LOCATION
-//                        ) != PackageManager.PERMISSION_GRANTED
-//                    ) {
-//                        error("메인 액티비티 - gps 권한이 없어서 터짐")
-//                    }
-//
-//                    val lm = getSystemService(Context.LOCATION_SERVICE) as LocationManager
-//
-//                    app.lastLocation = lm.getLastKnownLocation(LocationManager.GPS_PROVIDER)
-//
-//                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-//                        lm.getCurrentLocation(
-//                            LocationManager.GPS_PROVIDER,
-//                            null,
-//                            application.mainExecutor
-//                        ) {
-//                            app.lastLocation = it
-//                        }
-//                    }
-//
-//                    Log.d(JJTAG, "위치 갱신: ${app.lastLocation}")
-//                }
-//            } catch (e: Throwable) {
-//                Log.e(JJTAG, "위치 갱신하다 터짐: $e")
-//            }
-//        }
+        binding.vpMain.adapter = viewPagerAdapter
+        binding.vpMain.isUserInputEnabled = false
+        binding.vpMain.offscreenPageLimit = 4
+        binding.vpMain.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                binding.navView.menu.getItem(position).isChecked = true
+            }
+        })
 
-        val navView: BottomNavigationView = binding.navView
+        binding.navView.setOnItemSelectedListener {
+            when (it.itemId) {
+                R.id.navigation_home -> {
+                    binding.vpMain.setCurrentItem(0, false)
+                    return@setOnItemSelectedListener true
+                }
 
-        val navController = findNavController(R.id.nav_host_fragment_activity_main)
-        navView.setupWithNavController(navController)
-    }
+                R.id.navigation_map -> {
+                    binding.vpMain.setCurrentItem(1, false)
+                    return@setOnItemSelectedListener true
+                }
 
-    private fun hasPermission(): Boolean {
-        for (permission in permissions) {
-            if (ContextCompat.checkSelfPermission(this, permission)
-                != PackageManager.PERMISSION_GRANTED
-            ) {
-                return false
+                R.id.navigation_recommendation -> {
+                    binding.vpMain.setCurrentItem(2, false)
+                    return@setOnItemSelectedListener true
+                }
+
+                else -> {
+                    binding.vpMain.setCurrentItem(3, false)
+                    return@setOnItemSelectedListener true
+                }
             }
         }
-        return true
     }
 
     override fun onRequestPermissionsResult(
@@ -101,7 +75,7 @@ class MainActivity : AppCompatActivity() {
         permissions: Array<out String>,
         grantResults: IntArray
     ) {
-        Log.d(
+        DLog.d(
             JJTAG, "onRequestPermissionsResult requestCode: $requestCode" +
                     ", permissions: ${permissions.contentToString()}" +
                     ", grantResults: ${grantResults.contentToString()}"
@@ -110,13 +84,10 @@ class MainActivity : AppCompatActivity() {
         if (fusedLocationSource != null &&
             fusedLocationSource.onRequestPermissionsResult(requestCode, permissions, grantResults)
         ) {
-            Log.d(
+            DLog.d(
                 JJTAG, "onRequestPermissionsResult " +
                         "fusedLocationSource.isActivated: ${fusedLocationSource.isActivated}"
             )
-            if (!fusedLocationSource.isActivated) { // 권한 거부됨
-//                naverMap.locationTrackingMode = LocationTrackingMode.None
-            }
             return
         }
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/ViewPagerAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/ViewPagerAdapter.kt
@@ -1,0 +1,26 @@
+package com.wannabeinseoul.seoulpublicservice.ui.main
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.wannabeinseoul.seoulpublicservice.ui.home.HomeFragment
+import com.wannabeinseoul.seoulpublicservice.ui.map.MapFragment
+import com.wannabeinseoul.seoulpublicservice.ui.mypage.MyPageFragment
+import com.wannabeinseoul.seoulpublicservice.ui.recommendation.RecommendationFragment
+
+class ViewPagerAdapter(fragmentActivity: FragmentActivity): FragmentStateAdapter(fragmentActivity) {
+
+    private val fragments = listOf(
+        HomeFragment(),
+        MapFragment(),
+        RecommendationFragment(),
+        MyPageFragment()
+    )
+
+    override fun getItemCount(): Int {
+        return fragments.size
+    }
+
+    override fun createFragment(position: Int): Fragment = fragments[position]
+
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -393,7 +393,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     override fun onPause() {
         super.onPause()
         binding.etMapSearch.setText("")
-        viewModel.offStart()
         mapView.onPause()
     }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
@@ -100,10 +100,6 @@ class MapViewModel(
 
     fun getSavedPrefRepository() = getSavedServiceUseCase()
 
-    fun offStart() {
-        _canStart.value = false
-    }
-
     companion object {
         /** 뷰모델팩토리에서 의존성주입을 해준다 */
         val factory = viewModelFactory {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,29 +5,14 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/nav_view"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="0dp"
-        android:layout_marginEnd="0dp"
-        android:background="@color/total_background"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:menu="@menu/bottom_nav_menu" />
-
-    <fragment
-        android:id="@+id/nav_host_fragment_activity_main"
-        android:name="androidx.navigation.fragment.NavHostFragment"
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/vp_main"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:defaultNavHost="true"
         app:layout_constraintBottom_toTopOf="@id/nav_view"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/mobile_navigation" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.google.android.material.divider.MaterialDivider
         android:layout_width="match_parent"
@@ -36,4 +21,14 @@
         app:layout_constraintBottom_toTopOf="@+id/nav_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/nav_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/total_background"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:menu="@menu/bottom_nav_menu" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_detail_comment.xml
+++ b/app/src/main/res/layout/item_detail_comment.xml
@@ -10,7 +10,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:adjustViewBounds="true"
-        android:background="@color/gray"
+        android:background="@color/white"
         android:src="@drawable/ic_profile_image"
         android:scaleType="centerCrop"
         app:layout_constraintDimensionRatio="1:1"


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성

-기능
메인 액티비티 레이아웃 구조 변경

-설명
기존 바텀내비게이션뷰 + 내비 컨트롤러 구조에서 바텀내비게이션뷰 + 뷰페이저로 변경함
프래그먼트가 재생성되는 것을 막고 싶은데 기존 구조에서는 불가능했다.
그래서 뷰페이저로 바꾸고 스크롤 막고 screenPageLimit를 프래그먼트 사이즈만큼 주면서 프래그먼트 재생성을 막았다.
그래도 페이지 전환마다 onPause와 onResume은 실행된다.

## Merge 후 브랜치 보존 여부
(합친 브랜치는 삭제하는 것을 기본값으로 합니다. 브랜치를 유지할 필요가 있는 경우에 체크해주시기 바랍니다.)

- [ ] 반영된 브랜치 보존